### PR TITLE
allow compile as libraries (Do not merge just discussion)

### DIFF
--- a/libgen/CMakeLists.txt
+++ b/libgen/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(libpar)
+#find_package(PkgConfig REQUIRED)
+#pkg_search_module(CURL REQUIRED libcurl)
+
+set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} "-std=c11 -Wall")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-Wvla -Wall")
+
+include_directories(..)
+
+add_library(shapes MODULE shapes.c)
+add_library(msquares MODULE msquares.c)
+

--- a/libgen/msquares.c
+++ b/libgen/msquares.c
@@ -1,0 +1,3 @@
+
+#define PAR_MSQUARES_IMPLEMENTATION
+#include "par_msquares.h"

--- a/libgen/shapes.c
+++ b/libgen/shapes.c
@@ -1,0 +1,7 @@
+
+
+#define PAR_SHAPES_T uint32_t
+#define PAR_SHAPES_IMPLEMENTATION
+//#define TEST_PARSE
+//#define DUMP_TRACE
+#include "par_shapes.h"

--- a/par_shapes.h
+++ b/par_shapes.h
@@ -1094,7 +1094,7 @@ static par_shapes_mesh* par_shapes__apply_turtle(par_shapes_mesh* mesh,
     return m;
 }
 
-static void par_shapes__connect(par_shapes_mesh* scene,
+void par_shapes__connect(par_shapes_mesh* scene,
     par_shapes_mesh* cylinder, int slices)
 {
     int stacks = 1;

--- a/par_shapes.h
+++ b/par_shapes.h
@@ -1106,8 +1106,8 @@ void par_shapes__connect(par_shapes_mesh* scene,
     float* points = PAR_MALLOC(float, npoints * 3);
     memcpy(points, scene->points, sizeof(float) * scene->npoints * 3);
     float* newpts = points + scene->npoints * 3;
-    memcpy(newpts, cylinder->points + (slices + 1) * 3,
-        sizeof(float) * (slices + 1) * 3);
+    //memcpy(newpts, cylinder->points + (slices + 1) * 3,sizeof(float) * (slices + 1) * 3);
+    memcpy(newpts, cylinder->points ,sizeof(float) * (slices + 1) * 3);
     PAR_FREE(scene->points);
     scene->points = points;
 

--- a/par_shapes.h
+++ b/par_shapes.h
@@ -294,7 +294,7 @@ static float par_shapes__sqrdist3(float const* a, float const* b)
     return dx * dx + dy * dy + dz * dz;
 }
 
-static void par_shapes__compute_welded_normals(par_shapes_mesh* m)
+void par_shapes__compute_welded_normals(par_shapes_mesh* m)
 {
     m->normals = PAR_MALLOC(float, m->npoints * 3);
     PAR_SHAPES_T* weldmap = PAR_MALLOC(PAR_SHAPES_T, m->npoints);
@@ -1114,7 +1114,7 @@ void par_shapes__connect(par_shapes_mesh* scene,
     // Create the new triangle list.
     int ntriangles = scene->ntriangles + 2 * slices * stacks;
     PAR_SHAPES_T* triangles = PAR_MALLOC(PAR_SHAPES_T, ntriangles * 3);
-    memcpy(triangles, scene->triangles, 2 * scene->ntriangles * 3);
+    memcpy(triangles, scene->triangles, sizeof(PAR_SHAPES_T) * scene->ntriangles * 3);
     int v = scene->npoints - (slices + 1);
     PAR_SHAPES_T* face = triangles + scene->ntriangles * 3;
     for (int stack = 0; stack < stacks; stack++) {


### PR DESCRIPTION
This is for compiling par_shapes and msquares as libraries (I needed that for using luajit on them)
plus two corrections on connect function: first to allow exporting it, second for an error in it.