### PR TITLE
In par_shapes_create_lsystem, accept a random-number callback.

### DIFF
--- a/test/test_shapes.c
+++ b/test/test_shapes.c
@@ -266,7 +266,7 @@ int main()
             );
             const float O[3] = {0, 0, 0};
             const float J[3] = {0, 1, 0};
-            par_shapes_mesh* mesh = par_shapes_create_lsystem(program, 5, 60);
+            par_shapes_mesh* mesh = par_shapes_create_lsystem(program, 5, 60, NULL, NULL);
             par_shapes_mesh* disk = par_shapes_create_disk(10, 30, O, J);
             par_shapes_merge(mesh, disk);
             par_shapes_export(mesh, "build/lsystem.obj");


### PR DESCRIPTION
Thanks for accepting my previous PR.

In my environment, `rand()` might be used on other threads, resulting in inconsistent results, even if I call `srand()` prior to `par_shapes_create_lsystem()`.  This PR adds a callback, which enables me to use a PRNG with its own local context, so it isn't affected by other threads and doesn't affect other threads.