### PR TITLE
Realloc improvement in par_shapes

### DIFF
--- a/par_shapes.h
+++ b/par_shapes.h
@@ -194,7 +194,7 @@ void par_shapes__connect(par_shapes_mesh* scene, par_shapes_mesh* cylinder,
 #ifndef PAR_MALLOC
 #define PAR_MALLOC(T, N) ((T*) malloc(N * sizeof(T)))
 #define PAR_CALLOC(T, N) ((T*) calloc(N * sizeof(T), 1))
-#define PAR_REALLOC(T, BUF, N) ((T*) realloc(BUF, sizeof(T) * (N)))
+#define PAR_REALLOC(T, BUF, N, ORIGINAL_SIZE) ((T*) realloc(BUF, sizeof(T) * (N)))
 #define PAR_FREE(BUF) free(BUF)
 #endif
 
@@ -664,13 +664,14 @@ void par_shapes_set_epsilon_degenerate_sphere(float epsilon) {
 void par_shapes_merge(par_shapes_mesh* dst, par_shapes_mesh const* src)
 {
     PAR_SHAPES_T offset = dst->npoints;
+    int old_dst_npoints = dst->npoints;
     int npoints = dst->npoints + src->npoints;
     int vecsize = sizeof(float) * 3;
-    dst->points = PAR_REALLOC(float, dst->points, 3 * npoints);
+    dst->points = PAR_REALLOC(float, dst->points, 3 * npoints, 3 * old_dst_npoints);
     memcpy(dst->points + 3 * dst->npoints, src->points, vecsize * src->npoints);
     dst->npoints = npoints;
     if (src->normals || dst->normals) {
-        dst->normals = PAR_REALLOC(float, dst->normals, 3 * npoints);
+        dst->normals = PAR_REALLOC(float, dst->normals, 3 * npoints, 3 * old_dst_npoints);
         if (src->normals) {
             memcpy(dst->normals + 3 * offset, src->normals,
                 vecsize * src->npoints);
@@ -678,14 +679,14 @@ void par_shapes_merge(par_shapes_mesh* dst, par_shapes_mesh const* src)
     }
     if (src->tcoords || dst->tcoords) {
         int uvsize = sizeof(float) * 2;
-        dst->tcoords = PAR_REALLOC(float, dst->tcoords, 2 * npoints);
+        dst->tcoords = PAR_REALLOC(float, dst->tcoords, 2 * npoints, 2 * old_dst_npoints);
         if (src->tcoords) {
             memcpy(dst->tcoords + 2 * offset, src->tcoords,
                 uvsize * src->npoints);
         }
     }
     int ntriangles = dst->ntriangles + src->ntriangles;
-    dst->triangles = PAR_REALLOC(PAR_SHAPES_T, dst->triangles, 3 * ntriangles);
+    dst->triangles = PAR_REALLOC(PAR_SHAPES_T, dst->triangles, 3 * ntriangles, 3 * dst->ntriangles);
     PAR_SHAPES_T* ptriangles = dst->triangles + 3 * dst->ntriangles;
     PAR_SHAPES_T const* striangles = src->triangles;
     for (int i = 0; i < src->ntriangles; i++) {
@@ -1532,21 +1533,23 @@ par_shapes_mesh* par_shapes_clone(par_shapes_mesh const* mesh,
     if (!clone) {
         clone = PAR_CALLOC(par_shapes_mesh, 1);
     }
+    int old_clone_npoints = clone->npoints;
     clone->npoints = mesh->npoints;
-    clone->points = PAR_REALLOC(float, clone->points, 3 * clone->npoints);
+    clone->points = PAR_REALLOC(float, clone->points, 3 * clone->npoints, 3 * old_clone_npoints);
     memcpy(clone->points, mesh->points, sizeof(float) * 3 * clone->npoints);
+    int old_clone_ntriangles = clone->ntriangles;
     clone->ntriangles = mesh->ntriangles;
     clone->triangles = PAR_REALLOC(PAR_SHAPES_T, clone->triangles, 3 *
-        clone->ntriangles);
+        clone->ntriangles, 3 * old_clone_ntriangles);
     memcpy(clone->triangles, mesh->triangles,
         sizeof(PAR_SHAPES_T) * 3 * clone->ntriangles);
     if (mesh->normals) {
-        clone->normals = PAR_REALLOC(float, clone->normals, 3 * clone->npoints);
+        clone->normals = PAR_REALLOC(float, clone->normals, 3 * clone->npoints, 3 * old_clone_npoints);
         memcpy(clone->normals, mesh->normals,
             sizeof(float) * 3 * clone->npoints);
     }
     if (mesh->tcoords) {
-        clone->tcoords = PAR_REALLOC(float, clone->tcoords, 2 * clone->npoints);
+        clone->tcoords = PAR_REALLOC(float, clone->tcoords, 2 * clone->npoints, 3 * old_clone_npoints);
         memcpy(clone->tcoords, mesh->tcoords,
             sizeof(float) * 2 * clone->npoints);
     }

--- a/par_shapes.h
+++ b/par_shapes.h
@@ -194,7 +194,7 @@ void par_shapes__connect(par_shapes_mesh* scene, par_shapes_mesh* cylinder,
 #ifndef PAR_MALLOC
 #define PAR_MALLOC(T, N) ((T*) malloc(N * sizeof(T)))
 #define PAR_CALLOC(T, N) ((T*) calloc(N * sizeof(T), 1))
-#define PAR_REALLOC(T, BUF, N, SZ) ((T*) realloc(BUF, sizeof(T) * (N)))
+#define PAR_REALLOC(T, BUF, N, OLD_SZ) ((T*) realloc(BUF, sizeof(T) * (N)))
 #define PAR_FREE(BUF) free(BUF)
 #endif
 

--- a/par_shapes.h
+++ b/par_shapes.h
@@ -194,7 +194,7 @@ void par_shapes__connect(par_shapes_mesh* scene, par_shapes_mesh* cylinder,
 #ifndef PAR_MALLOC
 #define PAR_MALLOC(T, N) ((T*) malloc(N * sizeof(T)))
 #define PAR_CALLOC(T, N) ((T*) calloc(N * sizeof(T), 1))
-#define PAR_REALLOC(T, BUF, N, ORIGINAL_SIZE) ((T*) realloc(BUF, sizeof(T) * (N)))
+#define PAR_REALLOC(T, BUF, N, SZ) ((T*) realloc(BUF, sizeof(T) * (N)))
 #define PAR_FREE(BUF) free(BUF)
 #endif
 

--- a/test/test_shapes.c
+++ b/test/test_shapes.c
@@ -1,6 +1,20 @@
 #include "describe.h"
 
 #define PAR_SHAPES_IMPLEMENTATION
+
+// Used to test PAR_REALLOC
+void* par_realloc_wrapper(void* buf, int new_sz, int old_sz) {
+    void* new_buf = malloc(new_sz);
+    if (buf && old_sz) { memcpy(new_buf, buf, old_sz); }
+    if (buf) { free(buf); }
+    return new_buf;
+}
+
+#define PAR_MALLOC(T, N) ((T*) malloc(N * sizeof(T)))
+#define PAR_CALLOC(T, N) ((T*) calloc(N * sizeof(T), 1))
+#define PAR_REALLOC(T, BUF, N, SZ) ((T*)par_realloc_wrapper(BUF, sizeof(T) * N, sizeof(T) * SZ))
+#define PAR_FREE(BUF) free(BUF)
+
 #include "par_shapes.h"
 
 #include <fcntl.h>

--- a/test/test_shapes.c
+++ b/test/test_shapes.c
@@ -3,7 +3,7 @@
 #define PAR_SHAPES_IMPLEMENTATION
 
 // Used to test PAR_REALLOC
-void* par_realloc_wrapper(void* buf, int new_sz, int old_sz) {
+void* test_realloc(void* buf, int new_sz, int old_sz) {
     void* new_buf = malloc(new_sz);
     if (buf && old_sz) { memcpy(new_buf, buf, old_sz); }
     if (buf) { free(buf); }
@@ -12,7 +12,7 @@ void* par_realloc_wrapper(void* buf, int new_sz, int old_sz) {
 
 #define PAR_MALLOC(T, N) ((T*) malloc(N * sizeof(T)))
 #define PAR_CALLOC(T, N) ((T*) calloc(N * sizeof(T), 1))
-#define PAR_REALLOC(T, BUF, N, SZ) ((T*)par_realloc_wrapper(BUF, sizeof(T) * N, sizeof(T) * SZ))
+#define PAR_REALLOC(T, BUF, N, OLD_SZ) ((T*)test_realloc(BUF, sizeof(T) * N, sizeof(T) * OLD_SZ))
 #define PAR_FREE(BUF) free(BUF)
 
 #include "par_shapes.h"


### PR DESCRIPTION
## Rationale
Due to the design of `PAR_REALLOC` it can't work with some kinds of allocators that are not designed to support `realloc`. A good way to solve this, as seen in other libraries such as `stb`, is to have the `PAR_REALLOC` macro also provide the old size of the buffer. I specifically had this issue with `par_shapes` so I only provided a solution for that header.

## Changes
I changed the `PAR_REALLOC` macro to accept an extra parameter `OLD_SZ` that represents the old size.
The default implementation of the macro remains unchanged.
I then searched for all the uses of `PAR_REALLOC` in `par_shapes` and added the old size of the buffers to the `PAR_REALLOC` call. This sometimes involved creating new variables such as `int old_dst_npoints = dst->npoints;`.

## Testing
I tested my solution by adding a small `realloc` wrapper in `test_shapes.c` which uses `malloc` and `free` and overriding the `PAR_*` allocation macros.

All tests have passed when I ran them after I applied my changes.

## Considerations
This will affect people who already override `PAR_REALLOC` since they will have to add the extra parameter to the macro, however, if their `PAR_REALLOC` implementation already works without needing the old size then they can just ignore the `OLD_SZ` parameter, this is what the default implementation for `PAR_REALLOC` does too.

This will cause an inconsistency in the API however since all other `par` headers will still have the old-style `realloc`. If needed I can provide this change for the other `par` headers as well.