### PR TITLE
Set mesh to null in par_shapes_free_mesh

### DIFF
--- a/par_shapes.h
+++ b/par_shapes.h
@@ -487,6 +487,7 @@ void par_shapes_free_mesh(par_shapes_mesh* mesh)
     PAR_FREE(mesh->normals);
     PAR_FREE(mesh->tcoords);
     PAR_FREE(mesh);
+    mesh = null;
 }
 
 void par_shapes_export(par_shapes_mesh const* mesh, char const* filename)


### PR DESCRIPTION
Prior to this change dereferencing a mesh after it had been freed could be a hard to find bug. By setting the mesh to null you get an immediate crash on most systems, telling you right away what the error is.

See https://stackoverflow.com/questions/1025589