### PR TITLE
Support degenerate scaling and add `par_shapes_create_parametric_disk`

### DIFF
--- a/par_shapes.h
+++ b/par_shapes.h
@@ -70,6 +70,10 @@ par_shapes_mesh* par_shapes_create_cylinder(int slices, int stacks);
 // Again, height and radius are 1.0, but can be changed with par_shapes_scale.
 par_shapes_mesh* par_shapes_create_cone(int slices, int stacks);
 
+// Create a disk of radius 1.0 with texture coordinates and normals by squashing
+// a cone flat on the Z=0 plane.
+par_shapes_mesh* par_shapes_create_parametric_disk(int slices, int stacks);
+
 // Create a donut that sits on the Z=0 plane with the specified inner radius.
 // The outer radius can be controlled with par_shapes_scale.
 par_shapes_mesh* par_shapes_create_torus(int slices, int stacks, float radius);
@@ -347,6 +351,15 @@ par_shapes_mesh* par_shapes_create_cone(int slices, int stacks)
     }
     return par_shapes_create_parametric(par_shapes__cone, slices,
         stacks, 0);
+}
+
+par_shapes_mesh* par_shapes_create_parametric_disk(int slices, int stacks)
+{
+    par_shapes_mesh* m = par_shapes_create_cone(slices, stacks);
+    if (m) {
+        par_shapes_scale(m, 1.0f, 1.0f, 0.0f);
+    }
+    return m;
 }
 
 par_shapes_mesh* par_shapes_create_parametric_sphere(int slices, int stacks)
@@ -807,10 +820,19 @@ void par_shapes_scale(par_shapes_mesh* m, float x, float y, float z)
         *points++ *= z;
     }
     float* n = m->normals;
-    if (n && (x != y || x != z || y != z)) {
-        x = 1.0f / x;
-        y = 1.0f / y;
-        z = 1.0f / z;
+    if (n && !(x == y && y == z)) {
+        bool x_zero = x == 0;
+        bool y_zero = y == 0;
+        bool z_zero = z == 0;
+        if (!x_zero && !y_zero && !z_zero) {
+            x = 1.0f / x;
+            y = 1.0f / y;
+            z = 1.0f / z;
+        } else {
+            x = x_zero && !y_zero && !z_zero;
+            y = y_zero && !x_zero && !z_zero;
+            z = z_zero && !x_zero && !y_zero;
+        }
         for (int i = 0; i < m->npoints; i++, n += 3) {
             n[0] *= x;
             n[1] *= y;

--- a/test/test_shapes.c
+++ b/test/test_shapes.c
@@ -110,6 +110,14 @@ int main()
             par_shapes_export(m, "build/test_shapes_rock.obj");
             par_shapes_free_mesh(m);
 
+            m = par_shapes_create_cone(15, 3);
+            par_shapes_export(m, "build/test_shapes_cone.obj");
+            par_shapes_free_mesh(m);
+
+            m = par_shapes_create_parametric_disk(15, 3);
+            par_shapes_export(m, "build/test_shapes_parametric_disk.obj");
+            par_shapes_free_mesh(m);
+
             float center[3] = {0, 0, 0};
             float normal[3] = {0, 0, 1};
             m = par_shapes_create_disk(1, 5, center, normal);
@@ -160,6 +168,25 @@ int main()
             par_shapes_mesh* a;
             a = par_shapes_create_cylinder(15, 3);
             par_shapes_scale(a, 1, 1, 5);
+            par_shapes_free_mesh(a);
+        }
+        it("should support degenerate scale") {
+            par_shapes_mesh* a;
+            a = par_shapes_create_cone(15, 3);
+            assert_ok(a);
+            par_shapes_scale(a, 1, 1, 0);
+            for (int i = 0; i < a->npoints * 3; i++) {
+                // should not have nans
+                assert_ok(a->points[i] == a->points[i]);
+                assert_ok(a->normals[i] == a->normals[i]);
+                // check components
+                if (i % 3 != 2) {
+                    assert_ok(a->normals[i] == 0.0f);
+                } else {
+                    assert_ok(a->normals[i] == 1.0f);
+                    assert_ok(a->points[i] == 0.0f);
+                }
+            }
             par_shapes_free_mesh(a);
         }
     }


### PR DESCRIPTION
I noticed that by supporting degenerate scaling (scale factor zero) it's possible to use `par_shapes_create_cone` to create a disk shape with texture coordinates.

This also addresses a request for texture coordinates on a disk in https://github.com/prideout/par/issues/21