### PR TITLE
Fix compilation on newer GCC/glibc

### DIFF
--- a/par_string_blocks.h
+++ b/par_string_blocks.h
@@ -120,6 +120,10 @@ void parsb_write_blocks_to_file(parsb_context*, const char* filename);
 
 #ifdef PAR_STRING_BLOCKS_IMPLEMENTATION
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE  // required for str(n)dup
+#endif  // _GNU_SOURCE
+
 #include <assert.h>
 #include <ctype.h>
 #include <stdlib.h>


### PR DESCRIPTION
Either new GCC or new glibc changed things so that `str(n)dup` is no longer declared if `_GNU_SOURCE` is not defined. This can be done either by setting it in the source or changing the build script to set `-std=gnu11` instead of `-std=c11`. I chose the former.
