### PR TITLE
Fix heap-buffer-overflow in par_shapes_create_lsystem

### DIFF
--- a/par_shapes.h
+++ b/par_shapes.h
@@ -1259,6 +1259,9 @@ par_shapes_mesh* par_shapes_create_lsystem(char const* text, int slices,
     cmd = strtok(program, " ");
     while (cmd) {
         char *arg = strtok(0, " ");
+        if (!arg) {
+            break;
+        }
         if (!strcmp(cmd, "rule")) {
             current_rule++;
 


### PR DESCRIPTION
This PR fixes a heap-buffer-overflow (OOB Write) and a potential Null Pointer Dereference in `par_shapes_create_lsystem` when parsing an L-system program string with an odd number of tokens (a command missing its argument).

**Root Cause:**
In the first pass (token counting), if `strtok` returns `NULL` for `arg`, the loop correctly breaks and stops incrementing `ncommands`. However, the second pass (structure filling) lacks this check. It proceeds to process the unpaired token, resulting in a write past the bounds of the `commands` array allocated from the first pass's count. 
Additionally, if the unpaired token happens to be `"rule"`, it passes the `NULL` `arg` to `strchr()`, leading to a segfault.

**Fix:**
Added `if (!arg) break;` to the second pass to maintain symmetry with the first pass and ensure out-of-bounds writes and null pointer dereferences are prevented.