### PR TITLE
Fixed heap buffer overflow and compiler warning -Walloc-size-larger-than

### DIFF
--- a/par_shapes.h
+++ b/par_shapes.h
@@ -713,6 +713,12 @@ void par_shapes_merge(par_shapes_mesh* dst, par_shapes_mesh const* src)
 par_shapes_mesh* par_shapes_create_disk(float radius, int slices,
     float const* center, float const* normal)
 {
+    // Guard against degenerate and invalid tessellation counts
+    //  fixes compiler warning -Walloc-size-larger-than and heap buffer overflow
+    if (slices < 3) {
+        return 0;
+    }
+
     par_shapes_mesh* mesh = PAR_CALLOC(par_shapes_mesh, 1);
     mesh->npoints = slices + 1;
     mesh->points = PAR_MALLOC(float, 3 * mesh->npoints);


### PR DESCRIPTION
This PR fixes a heap buffer overflow and -Walloc-size-larger-than compiler warning when compiling with par_shapes.h traced to par_shapes_create_disk not validating if slices>=3. Negative slices cause heap-buffer-overflow crash.

tested:
- ASan repro on par_shapes_create_disk directly: crashes on negative slices before the fix, clean after, valid slice counts unaffected
- rebuilt using par_shapes.h, warning's gone